### PR TITLE
Pass query params to delete/update/create methods

### DIFF
--- a/example_api/views/stories.py
+++ b/example_api/views/stories.py
@@ -75,5 +75,5 @@ class StoriesView(BaseView):
             es_stories, _limit=self._query_params['_limit'])
 
         return self.Model._update_many(
-            stories, refresh_index=self.refresh_index,
-            **self._json_params)
+            stories, self._json_params,
+            refresh_index=self.refresh_index)

--- a/example_api/views/stories.py
+++ b/example_api/views/stories.py
@@ -30,7 +30,7 @@ class StoriesView(BaseView):
 
         return ES(self.Model.__name__).get_collection(
             _raw_terms=self._raw_terms,
-            **self._query_params)
+            self._query_params)
 
     def index(self):
         return self.get_collection_es()
@@ -41,14 +41,12 @@ class StoriesView(BaseView):
     def create(self):
         story = self.Model(**self._json_params)
         story.arbitrary_object = ArbitraryObject()
-        return story.save(refresh_index=self.refresh_index)
+        return story.save(self._query_params)
 
     def update(self, **kwargs):
         kwargs = self.resolve_kwargs(kwargs)
         story = self.Model.get_resource(**kwargs)
-        return story.update(
-            self._json_params,
-            refresh_index=self.refresh_index)
+        return story.update(self._json_params, self._query_params)
 
     def replace(self, **kwargs):
         return self.update(**kwargs)
@@ -56,7 +54,7 @@ class StoriesView(BaseView):
     def delete(self, **kwargs):
         kwargs = self.resolve_kwargs(kwargs)
         story = self.Model.get_resource(**kwargs)
-        story.delete(refresh_index=self.refresh_index)
+        story.delete(self._query_params)
 
     def delete_many(self):
         es_stories = self.get_collection_es()
@@ -66,8 +64,7 @@ class StoriesView(BaseView):
         if self.needs_confirmation():
             return stories
 
-        return self.Model._delete_many(
-            stories, refresh_index=self.refresh_index)
+        return self.Model._delete_many(stories, self._query_params)
 
     def update_many(self):
         es_stories = self.get_collection_es()
@@ -75,5 +72,4 @@ class StoriesView(BaseView):
             es_stories, _limit=self._query_params['_limit'])
 
         return self.Model._update_many(
-            stories, self._json_params,
-            refresh_index=self.refresh_index)
+            stories, self._json_params, self._query_params)

--- a/example_api/views/stories.py
+++ b/example_api/views/stories.py
@@ -30,7 +30,7 @@ class StoriesView(BaseView):
 
         return ES(self.Model.__name__).get_collection(
             _raw_terms=self._raw_terms,
-            self._query_params)
+            **self._query_params)
 
     def index(self):
         return self.get_collection_es()

--- a/example_api/views/users.py
+++ b/example_api/views/users.py
@@ -23,7 +23,7 @@ class UsersView(BaseView):
     def create(self):
         self._json_params.setdefault('groups', ['user'])
         user = self.Model(**self._json_params)
-        return user.save(self._query_params)
+        return user.save()
 
     def update(self, **kwargs):
         kwargs = self.resolve_kwargs(kwargs)
@@ -36,8 +36,7 @@ class UsersView(BaseView):
 
         if 'reset' in self._json_params:
             self._json_params.pop('reset', '')
-        return user.update(
-            self._json_params, self._query_params)
+        return user.update(self._json_params)
 
     def replace(self, **kwargs):
         return self.update(**kwargs)
@@ -45,7 +44,7 @@ class UsersView(BaseView):
     def delete(self, **kwargs):
         kwargs = self.resolve_kwargs(kwargs)
         story = self.Model.get_resource(**kwargs)
-        story.delete(self._query_params)
+        story.delete()
 
 
 class UserAttributesView(BaseView):
@@ -68,8 +67,7 @@ class UserAttributesView(BaseView):
         obj.update_iterables(
             self._json_params, self.attr,
             unique=self.unique,
-            value_type=self.value_type,
-            request_params=self._query_params)
+            value_type=self.value_type)
         return getattr(obj, self.attr, None)
 
 
@@ -85,15 +83,14 @@ class UserProfileView(BaseView):
         kwargs = self.resolve_kwargs(kwargs)
         obj = User.get_resource(**kwargs)
         profile = self.Model(**self._json_params)
-        profile = profile.save(self._query_params)
-        obj.update({'profile': profile}, self._query_params)
+        profile = profile.save()
+        obj.update({'profile': profile})
         return obj.profile
 
     def update(self, **kwargs):
         kwargs = self.resolve_kwargs(kwargs)
         user = User.get_resource(**kwargs)
-        return user.profile.update(
-            self._json_params, self._query_params)
+        return user.profile.update(self._json_params)
 
     def replace(self, **kwargs):
         return self.update(**kwargs)

--- a/example_api/views/users.py
+++ b/example_api/views/users.py
@@ -23,7 +23,7 @@ class UsersView(BaseView):
     def create(self):
         self._json_params.setdefault('groups', ['user'])
         user = self.Model(**self._json_params)
-        return user.save(refresh_index=self.refresh_index)
+        return user.save(self._query_params)
 
     def update(self, **kwargs):
         kwargs = self.resolve_kwargs(kwargs)
@@ -37,7 +37,7 @@ class UsersView(BaseView):
         if 'reset' in self._json_params:
             self._json_params.pop('reset', '')
         return user.update(
-            self._json_params, refresh_index=self.refresh_index)
+            self._json_params, self._query_params)
 
     def replace(self, **kwargs):
         return self.update(**kwargs)
@@ -45,7 +45,7 @@ class UsersView(BaseView):
     def delete(self, **kwargs):
         kwargs = self.resolve_kwargs(kwargs)
         story = self.Model.get_resource(**kwargs)
-        story.delete(refresh_index=self.refresh_index)
+        story.delete(self._query_params)
 
 
 class UserAttributesView(BaseView):
@@ -69,7 +69,7 @@ class UserAttributesView(BaseView):
             self._json_params, self.attr,
             unique=self.unique,
             value_type=self.value_type,
-            refresh_index=self.refresh_index)
+            request_params=self._query_params)
         return getattr(obj, self.attr, None)
 
 
@@ -85,16 +85,15 @@ class UserProfileView(BaseView):
         kwargs = self.resolve_kwargs(kwargs)
         obj = User.get_resource(**kwargs)
         profile = self.Model(**self._json_params)
-        profile = profile.save(refresh_index=self.refresh_index)
-        obj.update({'profile': profile}, refresh_index=self.refresh_index)
+        profile = profile.save(self._query_params)
+        obj.update({'profile': profile}, self._query_params)
         return obj.profile
 
     def update(self, **kwargs):
         kwargs = self.resolve_kwargs(kwargs)
         user = User.get_resource(**kwargs)
         return user.profile.update(
-            self._json_params,
-            refresh_index=self.refresh_index)
+            self._json_params, self._query_params)
 
     def replace(self, **kwargs):
         return self.update(**kwargs)


### PR DESCRIPTION
... instead of just passing `refresh_index`.

Query params are not passed to User model, because User model is not ES-based.
