### PR TITLE
Define proper ACLs. Set story owner.

### DIFF
--- a/example_api/acl.py
+++ b/example_api/acl.py
@@ -25,21 +25,13 @@ class UsersACL(CollectionACL):
     __acl__ = (
         (Allow, 'g:admin', ALL_PERMISSIONS),
         (Allow, Everyone, ('view', 'options')),
+        (Allow, Authenticated, 'create'),
         )
 
     def item_db_id(self, key):
         if key != 'self' or not self.request.user:
             return key
         return authenticated_userid(self.request)
-
-    def item_acl(self, item):
-        username = str(item.username)
-        return (
-            (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Everyone, ('view', 'options')),
-            (Allow, username, 'update'),
-            (Deny, username, 'delete'),
-            )
 
 
 class StoriesACL(DatabaseACLMixin, CollectionACL):

--- a/example_api/views/stories.py
+++ b/example_api/views/stories.py
@@ -28,6 +28,8 @@ class StoriesView(ACLFilterViewMixin, BaseView):
         return self.context
 
     def create(self):
+        if 'owner' not in self._json_params:
+            self._json_params['owner'] = self.request.user
         story = self.Model(**self._json_params)
         story.arbitrary_object = ArbitraryObject()
         return story.save(self.request)


### PR DESCRIPTION
`item_acl` deleted, because when acls-in-db used, item acl should be specified explicitly on object creation or edit.
